### PR TITLE
CIの導入で自動デプロイを実装

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -66,7 +66,15 @@ page 'developpers-guide/*.html', layout: 'with_sidemenu'
 # Build-specific configuration
 # https://middlemanapp.com/advanced/configuration/#environment-specific-settings
 
-# configure :build do
-#   activate :minify_css
-#   activate :minify_javascript
-# end
+configure :build do
+  after_build do |builder|
+    #bundle exec middleman build --verbose -e $WERCKER_GIT_BRANCH
+    branch_name = ARGV[3]
+    if branch_name != 'master'
+      puts "ブランチ名:#{branch_name}"
+      Dir.glob("./build/**/*.html").each do |path|
+          builder.thor.gsub_file path, /href="\//, "href=\"/testsite/#{branch_name}/"
+      end
+    end
+  end
+end

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,29 @@
+box: ruby:2.5.1
+build:
+  steps:
+    - bigtruedata/install-node
+    - bundle-install
+    # middleman build ブランチ名を環境変数として渡す
+    - script:
+      name: middleman build
+      code: bundle exec middleman build --verbose -e $WERCKER_GIT_BRANCH
+deploy-test-site:
+  steps:
+    - add-to-known_hosts:
+      hostname: gtfs.jp
+    - mktemp:
+      envvar: PRIVATEKEY_PATH
+    # werckerで設定したsshの秘密鍵の環境変数を基に秘密鍵を生成
+    - create-file:
+      name: Create private key
+      filename: $PRIVATEKEY_PATH
+      content: $PRIVATE_KEY
+      overwrite: true
+    # sshでアップ先ディレクトリを作成
+    - script:
+      name: ssh and mkdir
+      code: ssh -i $PRIVATEKEY_PATH $USER@gtfs.jp mkdir -p /home/gtfs/www/testsite/$WERCKER_GIT_BRANCH
+    # scpでデプロイ
+    - script:
+      name: deploy testsite with scp
+      code: scp -i $PRIVATEKEY_PATH -r build/* $USER@gtfs.jp:/home/gtfs/www/testsite/$WERCKER_GIT_BRANCH

--- a/wercker.yml
+++ b/wercker.yml
@@ -7,6 +7,24 @@ build:
     - script:
       name: middleman build
       code: bundle exec middleman build --verbose -e $WERCKER_GIT_BRANCH
+# masterのデプロイ
+deploy-production:
+  steps:
+    - add-to-known_hosts:
+      hostname: gtfs.jp
+    - mktemp:
+      envvar: PRIVATEKEY_PATH
+    # werckerで設定したsshの秘密鍵の環境変数を基に秘密鍵を生成
+    - create-file:
+      name: Create private key
+      filename: $PRIVATEKEY_PATH
+      content: $PRIVATE_KEY
+      overwrite: true
+    # scpでデプロイ
+    - script:
+      name: deploy testsite with scp
+      code: scp -i $PRIVATEKEY_PATH -r build/* $USER@gtfs.jp:/home/gtfs/www
+# テストサイトのデプロイ
 deploy-test-site:
   steps:
     - add-to-known_hosts:


### PR DESCRIPTION
werckerを導入しました。
ビルドしたファイル群をmasterプッシュがあった時は`/`以下に、それ以外のブランチは`/testsite/{{ブランチ名}}` 以下に自動でデプロイします。
werckerのアプリケーションページは[ここ](https://app.wercker.com/kumatira/GTFS-JP-web/runs)です

テストサイトのアドレスは
`https://www.gtfs.jp/testsite/{{ブランチ名}}` 

本ブランチなら
https://www.gtfs.jp/testsite/add/wercker_setting/