### PR TITLE
日本地図をアップデート。西沢先生公開の画像を直接読み込むように変更。

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -66,7 +66,7 @@
     <p>GTFS-JPにしたがって作られたオープンデータが日本全国で公開され始めています。同じ形式のデータであるため、GTFS-JPに対応したアプリケーションであればどのデータでも容易に取り込むことができます。</p>
     <a href="http://tshimada291.sakura.ne.jp/transport/gtfs-list.html" class="waves-effect waves-light btn-large blue accent-1" target="_blank" target="_blank">公開データ一覧</a>
     <div class="row">
-      <%= image_tag('images/japan_map.png',:class => 'responsive-img japan-map') %>
+      <%= image_tag('https://home.csis.u-tokyo.ac.jp/~nishizawa/gtfs/gtfs-jp-map.png',:class => 'responsive-img japan-map') %>
     </div>
   </div>
 </main>


### PR DESCRIPTION
トップにある日本地図の画像が古いままなので、西沢先生のサーバURLを直接参照してそこから読み込むように変更しました。

# 対応issue(あれば)


# テストサイト
https://www.gtfs.jp/testsite/update-japan-map/
