### PR TITLE
画像リンク切れの修正

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -21,7 +21,7 @@
     <p>GTFS-JPにしたがって作られたオープンデータが日本全国で公開され始めています。同じ形式のデータであるため、GTFS-JPに対応したアプリケーションであればどのデータでも容易に取り込むことができます。</p>
     <a href="http://tshimada291.sakura.ne.jp/transport/gtfs-list.html" class="waves-effect waves-light btn-large blue accent-1" target="_blank" target="_blank">公開データ一覧</a>
     <div class="row">
-      <%= image_tag('https://home.csis.u-tokyo.ac.jp/~nishizawa/gtfs/gtfs-jp-map.png',:class => 'responsive-img japan-map') %>
+      <%= image_tag('https://gtfs-gis.jp/gtfs/gtfs-jp-map.png',:class => 'responsive-img japan-map') %>
     </div>
   </div>
 </main>


### PR DESCRIPTION
トップページのオープンデータマップの画像リンクが切れていたため、適切なURLに置き換えました。


# テストサイト
https://www.gtfs.jp/testsite/fix/top_page_map

Werckerがサービス終了していたため手動でアップしました。
